### PR TITLE
Fix code scanning alert no. 2: Cross-site scripting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ wrapper {
 }
 
 dependencies {
+    implementation 'org.owasp.encoder:encoder:1.3.1'
     //Kotlin
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
     implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")

--- a/src/main/kotlin/finance/controllers/UserController.kt
+++ b/src/main/kotlin/finance/controllers/UserController.kt
@@ -1,4 +1,5 @@
 package finance.controllers
+import org.owasp.encoder.Encode
 
 import finance.domain.User
 import finance.services.UserService
@@ -19,7 +20,9 @@ class UserController @Autowired constructor(private var userService: UserService
 
     @PostMapping("/signup")
     fun signUp( @RequestBody user: User): ResponseEntity<String> {
-        return ResponseEntity.ok(mapper.writeValueAsString(user))
+        val jsonString = mapper.writeValueAsString(user)
+        val encodedJsonString = org.owasp.encoder.Encode.forHtmlContent(jsonString)
+        return ResponseEntity.ok(encodedJsonString)
     }
 
 //    @GetMapping(value = "/whoami")


### PR DESCRIPTION
Fixes [https://github.com/henninb/raspi-finance-endpoint/security/code-scanning/2](https://github.com/henninb/raspi-finance-endpoint/security/code-scanning/2)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data is properly sanitized or encoded before being included in the response. In this case, we can use a library like `org.owasp.encoder.Encode` to encode the JSON string before returning it in the response. This will prevent any malicious scripts from being executed in the user's browser.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
