### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,9 @@
 
 name: Labeler
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
Potential fix for [https://github.com/henninb/raspi-finance-endpoint/security/code-scanning/9](https://github.com/henninb/raspi-finance-endpoint/security/code-scanning/9)

The best fix is to add a `permissions` key with least privilege settings as high as possible in the workflow—either at the top level (affecting all jobs), or directly in the affected job (`label`). Since the workflow only has one job (`label`), both are acceptable. To follow the CodeQL suggestion and avoid affecting only some jobs if more are added later, add the block at the workflow root (line 10, just after `on`). The recommended minimal permissions for this workflow are `contents: read` and `pull-requests: write`. No further changes, imports, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
